### PR TITLE
feat(monorepo): add worktree removal in pre-push script

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -22,4 +22,11 @@ pnpm bundle:analyze || {
   echo "⚠️  Bundle analysis failed, but allowing push"
 }
 
+# Remove the current worktree if not in the main repository directory
+if [ -f .git ] && grep -q "gitdir: ../.git/worktrees/" .git; then
+  branch=$(git rev-parse --abbrev-ref HEAD)
+  git worktree remove .
+  echo "Worktree removed for branch $branch"
+fi
+
 echo "✅ Pre-push validations completed successfully"


### PR DESCRIPTION
This PR adds automatic worktree removal to the pre-push script in the monorepo. It ensures that temporary worktree environments are cleaned up before pushing, helping to keep the repository organized and preventing conflicts or leftover temporary branches.